### PR TITLE
Zoom in and out with icon buttons

### DIFF
--- a/src/npld-player.ts
+++ b/src/npld-player.ts
@@ -91,8 +91,11 @@ export class NPLDPlayer extends LitElement {
   private webview?: any;
 
   updated(changedProperties: Map<string, any>) {
-    if (changedProperties.has('zoomLevel')) {
-      this.webview?.setZoomLevel(this.zoomLevel);
+    if (
+      changedProperties.get('zoomLevel') !== undefined &&
+      changedProperties.has('zoomLevel')
+    ) {
+      this.zoomWebview();
     }
   }
 
@@ -229,6 +232,14 @@ export class NPLDPlayer extends LitElement {
     if (this.zoomLevel > NPLDPlayer.zoomLevelMin) {
       this.zoomLevel -= 1;
     }
+  }
+
+  private zoomWebview() {
+    if (!this.webview || this.webview.getZoomLevel() === this.zoomLevel) {
+      return;
+    }
+
+    this.webview.setZoomLevel(this.zoomLevel);
   }
 
   private printPage() {

--- a/src/npld-player.ts
+++ b/src/npld-player.ts
@@ -66,6 +66,10 @@ export class NPLDPlayer extends LitElement {
     }
   `;
 
+  // Chromium visual zoom minimum/maximum level
+  static zoomLevelMax = 9;
+  static zoomLevelMin = -8;
+
   @property({ type: String })
   private url = '';
 
@@ -78,8 +82,19 @@ export class NPLDPlayer extends LitElement {
   @state()
   private canGoForward = false;
 
+  // https://www.electronjs.org/docs/latest/api/webview-tag#webviewsetzoomlevellevel
+  @state()
+  private zoomLevel = 0;
+
+  // https://www.electronjs.org/docs/latest/api/webview-tag#tag-attributes
   @query('webview')
   private webview?: any;
+
+  updated(changedProperties: Map<string, any>) {
+    if (changedProperties.has('zoomLevel')) {
+      this.webview?.setZoomLevel(this.zoomLevel);
+    }
+  }
 
   render() {
     return html` ${this.renderAppBar()} ${this.renderMain()}`;
@@ -125,11 +140,13 @@ export class NPLDPlayer extends LitElement {
           name="zoom-in"
           label="Zoom in"
           @click=${this.zoomIn}
+          ?disabled=${this.zoomLevel === NPLDPlayer.zoomLevelMax}
         ></sl-icon-button>
         <sl-icon-button
           name="zoom-out"
           label="Zoom out"
           @click=${this.zoomOut}
+          ?disabled=${this.zoomLevel === NPLDPlayer.zoomLevelMin}
         ></sl-icon-button>
         <sl-icon-button
           name="printer"
@@ -203,11 +220,15 @@ export class NPLDPlayer extends LitElement {
   }
 
   private zoomIn() {
-    console.log('TODO zoomIn');
+    if (this.zoomLevel < NPLDPlayer.zoomLevelMax) {
+      this.zoomLevel += 1;
+    }
   }
 
   private zoomOut() {
-    console.log('TODO zoomOut');
+    if (this.zoomLevel > NPLDPlayer.zoomLevelMin) {
+      this.zoomLevel -= 1;
+    }
   }
 
   private printPage() {

--- a/src/npld-player.ts
+++ b/src/npld-player.ts
@@ -186,7 +186,7 @@ export class NPLDPlayer extends LitElement {
       <main>
         <webview
           src=${this.url}
-          @dom-ready=${() => (this.isReady = true)}
+          @dom-ready=${this.onWebviewReady}
           @did-start-loading=${() => (this.isLoading = true)}
           @did-stop-loading=${() => (this.isLoading = false)}
           @did-finish-loading=${() => (this.isLoading = false)}
@@ -216,6 +216,11 @@ export class NPLDPlayer extends LitElement {
         >
       </div>
     `;
+  }
+
+  private onWebviewReady() {
+    this.zoomFactor = this.webview.getZoomFactor();
+    this.isReady = true;
   }
 
   private onNavigate() {

--- a/src/npld-player.ts
+++ b/src/npld-player.ts
@@ -17,6 +17,8 @@ export class NPLDPlayer extends LitElement {
     }
 
     .icon-button-group {
+      display: flex;
+      align-items: center;
       padding: 2px 5px;
       user-select: none;
     }
@@ -54,6 +56,17 @@ export class NPLDPlayer extends LitElement {
       color: var(--sl-color-neutral-500);
     }
 
+    .zoom-scale-label {
+      display: inline-block;
+      background-color: var(--sl-color-neutral-100);
+      color: var(--sl-color-neutral-600);
+      padding: 0.25rem;
+      border-radius: var(--sl-border-radius-small);
+      width: 2.5rem;
+      font-size: var(--sl-font-size-x-small);
+      text-align: center;
+    }
+
     sl-icon-button {
       font-size: 1.25rem;
     }
@@ -66,12 +79,11 @@ export class NPLDPlayer extends LitElement {
     }
   `;
 
-  // Chromium visual zoom minimum/maximum level
-  static zoomLevelMax = 9;
-  static zoomLevelMin = -8;
-
   @property({ type: String })
   private url = '';
+
+  @state()
+  private isReady = false;
 
   @state()
   private isLoading = false;
@@ -82,22 +94,15 @@ export class NPLDPlayer extends LitElement {
   @state()
   private canGoForward = false;
 
-  // https://www.electronjs.org/docs/latest/api/webview-tag#webviewsetzoomlevellevel
-  @state()
-  private zoomLevel = 0;
-
   // https://www.electronjs.org/docs/latest/api/webview-tag#tag-attributes
   @query('webview')
   private webview?: any;
 
-  updated(changedProperties: Map<string, any>) {
-    if (
-      changedProperties.get('zoomLevel') !== undefined &&
-      changedProperties.has('zoomLevel')
-    ) {
-      this.zoomWebview();
-    }
-  }
+  // https://www.electronjs.org/docs/latest/api/webview-tag#webviewsetzoomfactorfactor
+  @state()
+  private zoomFactor = 1;
+
+  private zoomLevel = 0;
 
   render() {
     return html` ${this.renderAppBar()} ${this.renderMain()}`;
@@ -139,17 +144,33 @@ export class NPLDPlayer extends LitElement {
       </div>
       ${this.renderWebAddress()}
       <div class="icon-button-group">
+        ${this.zoomFactor !== 1
+          ? html`<div
+                class="zoom-scale-label"
+                aria-label="Zoom scale"
+                aria-live="polite"
+              >
+                ${(this.zoomFactor * 100).toFixed(0)}%
+              </div>
+
+              <sl-button variant="text" size="small" @click=${this.resetZoom}
+                >Reset</sl-button
+              > `
+          : html``}
+
         <sl-icon-button
           name="zoom-in"
           label="Zoom in"
           @click=${this.zoomIn}
-          ?disabled=${this.zoomLevel === NPLDPlayer.zoomLevelMax}
+          ?disabled=${NPLDPlayer.zoomFactorMap[this.zoomLevel + 1] ===
+          undefined}
         ></sl-icon-button>
         <sl-icon-button
           name="zoom-out"
           label="Zoom out"
           @click=${this.zoomOut}
-          ?disabled=${this.zoomLevel === NPLDPlayer.zoomLevelMin}
+          ?disabled=${NPLDPlayer.zoomFactorMap[this.zoomLevel - 1] ===
+          undefined}
         ></sl-icon-button>
         <sl-icon-button
           name="printer"
@@ -165,6 +186,7 @@ export class NPLDPlayer extends LitElement {
       <main>
         <webview
           src=${this.url}
+          @dom-ready=${() => (this.isReady = true)}
           @did-start-loading=${() => (this.isLoading = true)}
           @did-stop-loading=${() => (this.isLoading = false)}
           @did-finish-loading=${() => (this.isLoading = false)}
@@ -223,26 +245,53 @@ export class NPLDPlayer extends LitElement {
   }
 
   private zoomIn() {
-    if (this.zoomLevel < NPLDPlayer.zoomLevelMax) {
-      this.zoomLevel += 1;
-    }
+    this.zoomLevel += 1;
+    this.updateZoomFactor();
   }
 
   private zoomOut() {
-    if (this.zoomLevel > NPLDPlayer.zoomLevelMin) {
-      this.zoomLevel -= 1;
-    }
+    this.zoomLevel -= 1;
+    this.updateZoomFactor();
   }
 
-  private zoomWebview() {
-    if (!this.webview || this.webview.getZoomLevel() === this.zoomLevel) {
-      return;
-    }
+  private resetZoom() {
+    this.zoomLevel = 0;
+    this.updateZoomFactor();
+  }
 
-    this.webview.setZoomLevel(this.zoomLevel);
+  private updateZoomFactor() {
+    const factor = NPLDPlayer.zoomFactorMap[this.zoomLevel];
+
+    if (factor !== undefined) {
+      this.webview.setZoomFactor(factor);
+      this.zoomFactor = factor;
+    }
   }
 
   private printPage() {
     console.log('TODO printPage');
   }
+
+  // Map zoom level to zoom factor
+  // Manually copied from Chrome, the Chromium max is
+  // 500% and min and 25%
+  static zoomFactorMap: Record<number, number> = {
+    9: 5.0,
+    8: 4.0,
+    7: 3.0,
+    6: 2.5,
+    5: 2.0,
+    4: 1.75,
+    3: 1.5,
+    2: 1.25,
+    1: 1.1,
+    0: 1.0,
+    [-1]: 0.9,
+    [-2]: 0.8,
+    [-3]: 0.75,
+    [-4]: 0.67,
+    [-5]: 0.5,
+    [-6]: 0.33,
+    [-7]: 0.25,
+  };
 }


### PR DESCRIPTION
https://github.com/ukwa/npld-player/issues/5 Allows user to zoom in and out of webview using app bar buttons.

### Manual testing
1. Run app with `yarn start`. Click magnifying glass with `+` icon. Verify webview zooms in and zoom scale is shown.
2. Click magnifying glass with `-` icon. Verify webview zooms out.
3. Click "Reset" button. Verify webview zoom is reset.

### Demo

https://user-images.githubusercontent.com/4672952/167982166-9bb6698f-d181-43a8-b0ca-8efc8decffb2.mov

### TODO
Investigate detecting zoom event (e.g. with keyboard shortcut.) Tried a few things, like:
- Adding `this.webview.addEventListener('resize')` -- although the resize event would trigger when the app resized, zoom in with keyboard shortcuts did not
- Adding keydown event -- this works on the main window, but is actually disallowed per [docs] in the webview

There may be a way to capture the event in the main or preload script instead.