### PR TITLE
Fix icon image paths in packaged app

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -12,4 +12,5 @@ import './index.css';
 import './npld-player';
 
 // Set the base path to the folder you copied Shoelace's assets to
-setBasePath('./public/shoelace');
+const isLocalFile = window.location.origin === 'file://';
+setBasePath(`${isLocalFile ? '.' : window.location.href}/public/shoelace`);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -12,4 +12,4 @@ import './index.css';
 import './npld-player';
 
 // Set the base path to the folder you copied Shoelace's assets to
-setBasePath('public/shoelace');
+setBasePath('./public/shoelace');

--- a/webpack.plugins.js
+++ b/webpack.plugins.js
@@ -21,7 +21,10 @@ module.exports = [
           __dirname,
           'node_modules/@shoelace-style/shoelace/dist/assets'
         ),
-        to: path.resolve(__dirname, '.webpack/renderer/public/shoelace/assets'),
+        to: path.resolve(
+          __dirname,
+          '.webpack/renderer/main_window/public/shoelace/assets'
+        ),
       },
     ],
   }),


### PR DESCRIPTION
Fixes https://github.com/ukwa/npld-player/issues/22

### Manual testing
1. Run app with `yarn start`. Verify that icons in app bar show
2. Build app with `yarn make` and open packaged app in `out/npld-player-{build}`. Verify icons show