### PR TITLE
Disable dev tools toggle in packaged app

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ const createWindow = (): void => {
     width: 800,
     webPreferences: {
       webviewTag: true, // Enable <webview>
+      devTools: isDev,
       preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
     },
   });


### PR DESCRIPTION
(https://github.com/ukwa/npld-player/issues/23) Prevents users from toggle developer tools in the packaged app.

### Manual test
1. Build package with `yarn make`
2. Open app. Attempt to toggle dev tools with keyboard shortcut. Verify that dev tools do not open