### PR TITLE
Fix error on webview first load

### DIFF
--- a/src/npld-player.ts
+++ b/src/npld-player.ts
@@ -82,7 +82,7 @@ export class NPLDPlayer extends LitElement {
   `;
 
   @state()
-  private webviewUrl: string = NPLDPlayer.initialWebAddress;
+  private webviewUrlDisplay: string = NPLDPlayer.initialWebAddress;
 
   @state()
   private isReady = false;
@@ -187,7 +187,7 @@ export class NPLDPlayer extends LitElement {
     return html`
       <main>
         <webview
-          src=${this.webviewUrl}
+          src=${NPLDPlayer.initialWebAddress}
           allowpopups
           @dom-ready=${this.onWebviewReady}
           @did-start-loading=${() => (this.isLoading = true)}
@@ -204,12 +204,12 @@ export class NPLDPlayer extends LitElement {
     let url: URL;
 
     try {
-      url = new URL(this.webviewUrl);
+      url = new URL(this.webviewUrlDisplay);
     } catch {
       return '';
     }
 
-    const [prefix, suffix] = this.webviewUrl.split(url.hostname);
+    const [prefix, suffix] = this.webviewUrlDisplay.split(url.hostname);
 
     return html`
       <div class="address-field" tabindex="0">
@@ -227,7 +227,7 @@ export class NPLDPlayer extends LitElement {
   }
 
   private onNavigate() {
-    this.webviewUrl = this.webview.getURL();
+    this.webviewUrlDisplay = this.webview.getURL();
     this.canGoBack = this.webview.canGoBack();
     this.canGoForward = this.webview.canGoForward();
   }

--- a/src/npld-player.ts
+++ b/src/npld-player.ts
@@ -192,7 +192,7 @@ export class NPLDPlayer extends LitElement {
           @dom-ready=${this.onWebviewReady}
           @did-start-loading=${() => (this.isLoading = true)}
           @did-stop-loading=${() => (this.isLoading = false)}
-          @did-finish-loading=${() => (this.isLoading = false)}
+          @did-finish-load=${() => (this.isLoading = false)}
           @did-fail-load=${() => (this.isLoading = false)}
           @did-navigate=${this.onNavigate}
         ></webview>

--- a/src/npld-player.ts
+++ b/src/npld-player.ts
@@ -190,10 +190,8 @@ export class NPLDPlayer extends LitElement {
           src=${NPLDPlayer.initialWebAddress}
           allowpopups
           @dom-ready=${this.onWebviewReady}
-          @did-start-loading=${() => (this.isLoading = true)}
-          @did-stop-loading=${() => (this.isLoading = false)}
-          @did-finish-load=${() => (this.isLoading = false)}
-          @did-fail-load=${() => (this.isLoading = false)}
+          @did-start-loading=${this.onLoadStart}
+          @did-stop-loading=${this.onLoadEnd}
           @did-navigate=${this.onNavigate}
         ></webview>
       </main>
@@ -221,11 +219,31 @@ export class NPLDPlayer extends LitElement {
     `;
   }
 
+  /**
+   * Callback when the spinner of the tab starts spinning.
+   */
+  private onLoadStart() {
+    this.isLoading = true;
+  }
+
+  /**
+   * Callback when the spinner of the tab stops spinning.
+   */
+  private onLoadEnd() {
+    this.isLoading = false;
+  }
+
+  /**
+   * Callback when document in the webview is loaded.
+   */
   private onWebviewReady() {
     this.zoomFactor = this.webview.getZoomFactor();
     this.isReady = true;
   }
 
+  /**
+   * Callback when a navigation is done.
+   */
   private onNavigate() {
     this.webviewUrlDisplay = this.webview.getURL();
     this.canGoBack = this.webview.canGoBack();


### PR DESCRIPTION
Fixes https://github.com/ukwa/npld-player/issues/28 by preventing changes to webview `src` attribute on first load, and some minor cleanup.

See https://github.com/electron/electron/issues/24608

### Manual testing
Run app with `yarn start`. Verify that webview loads as expected and error does not show in dev tools console log.