### PR TITLE
Misc fixes for reentrancy + prod build

### DIFF
--- a/src/npld-player.ts
+++ b/src/npld-player.ts
@@ -189,6 +189,7 @@ export class NPLDPlayer extends LitElement {
         <webview
           src=${NPLDPlayer.initialWebAddress}
           allowpopups
+          partition="content"
           @dom-ready=${this.onWebviewReady}
           @did-start-loading=${this.onLoadStart}
           @did-stop-loading=${this.onLoadEnd}

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -1,3 +1,5 @@
+const plugins = require('./webpack.plugins');
+
 module.exports = {
   /**
    * This is the main entry point for your application, it's the first file
@@ -8,6 +10,7 @@ module.exports = {
   module: {
     rules: require('./webpack.rules'),
   },
+  plugins,
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],
   },


### PR DESCRIPTION
Fixes some misc issues with reopening window, env vars and uses separate session for the webview.

Some remaining questions/remaining issues:
- Currently disabled keeping process open on MacOS without window, seems to have no reason since app generally opened from URL?
- Should the app support multiple open windows for each `npld-viewer://`, or reuse one? (currently one)
- Disabled the CSP policy via header injection for main app, but can probably add later to index.html
- Still untested on Windows